### PR TITLE
fix: import list commands from @lexical/list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,3 +83,4 @@
 ### Notable Note-taking
 - Component: `src/components/Notable.jsx` (route `/notable`).
 - Lexical-based editor for local notes with export/import options.
+- List insertion commands (`INSERT_ORDERED_LIST_COMMAND`, `INSERT_UNORDERED_LIST_COMMAND`) are exported from `@lexical/list`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,4 @@
 - Component: `src/components/Notable.jsx` (route `/notable`).
 - Lexical-based editor for local notes with export/import options.
 - List insertion commands (`INSERT_ORDERED_LIST_COMMAND`, `INSERT_UNORDERED_LIST_COMMAND`) are exported from `@lexical/list`.
+- Code blocks: `@lexical/code` has no `INSERT_CODE_BLOCK_COMMAND`; use `$setBlocksType` with `$createCodeNode`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -136,3 +136,4 @@ Notes:
 - Component: `src/components/Notable.jsx` (route `/notable`).
 - Offline-first Lexical editor for quick local notes; supports import/export and Markdown shortcuts.
 - List insertion commands (`INSERT_ORDERED_LIST_COMMAND`, `INSERT_UNORDERED_LIST_COMMAND`) come from `@lexical/list`.
+- Code blocks: `@lexical/code` lacks `INSERT_CODE_BLOCK_COMMAND`; use `$setBlocksType` with `$createCodeNode`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -135,3 +135,4 @@ Notes:
 ### Notable Note-taking
 - Component: `src/components/Notable.jsx` (route `/notable`).
 - Offline-first Lexical editor for quick local notes; supports import/export and Markdown shortcuts.
+- List insertion commands (`INSERT_ORDERED_LIST_COMMAND`, `INSERT_UNORDERED_LIST_COMMAND`) come from `@lexical/list`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,15 @@
         "@ffmpeg/core": "0.12.6",
         "@ffmpeg/ffmpeg": "0.12.6",
         "@ffmpeg/util": "^0.12.2",
+        "@lexical/code": "^0.15.0",
+        "@lexical/link": "^0.15.0",
+        "@lexical/list": "^0.15.0",
+        "@lexical/markdown": "^0.15.0",
+        "@lexical/react": "^0.15.0",
+        "@lexical/rich-text": "^0.15.0",
+        "@lexical/selection": "^0.15.0",
         "@tabler/icons-react": "^3.34.1",
+        "lexical": "^0.15.0",
         "marked": "^12.0.2",
         "pdfjs-dist": "^3.11.174",
         "react": "^18.3.1",
@@ -1592,7 +1600,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2268,6 +2275,260 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lexical/clipboard": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.15.0.tgz",
+      "integrity": "sha512-binCltK7KiURQJFogvueYfmDNEKynN/lmZrCLFp2xBjEIajqw4WtOVLJZ33engdqNlvj0JqrxrWxbKG+yvUwrg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/html": "0.15.0",
+        "@lexical/list": "0.15.0",
+        "@lexical/selection": "0.15.0",
+        "@lexical/utils": "0.15.0",
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/code": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.15.0.tgz",
+      "integrity": "sha512-n185gjinGhz/M4BW1ayNPYAEgwW4T/NEFl2Wey/O+07W3zvh9k9ai7RjWd0c8Qzqc4DLlqvibvWPebWObQHA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.15.0",
+        "lexical": "0.15.0",
+        "prismjs": "^1.27.0"
+      }
+    },
+    "node_modules/@lexical/devtools-core": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.15.0.tgz",
+      "integrity": "sha512-kK/IVEiQyqs2DsY4QRYFaFiKQMpaAukAl8PXmNeGTZ7cfFVsP29E4n0/pjY+oxmiRvxbO1s2i14q58nfuhj4VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/html": "0.15.0",
+        "@lexical/link": "0.15.0",
+        "@lexical/mark": "0.15.0",
+        "@lexical/table": "0.15.0",
+        "@lexical/utils": "0.15.0",
+        "lexical": "0.15.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.x",
+        "react-dom": ">=17.x"
+      }
+    },
+    "node_modules/@lexical/dragon": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.15.0.tgz",
+      "integrity": "sha512-hg2rGmxVJF7wmN6psuKw3EyhcNF7DtOYwUCBpjFZVshzAjsNEBfEnqhiMkSVSlN4+WOfM7LS+B88PTKPcnFGbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/hashtag": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.15.0.tgz",
+      "integrity": "sha512-EP6KKvS6BY/8Vh1MLQYeOcYaxnvrLsUkvXXr+Fg8N477Us54Ju69pPO563mbWt7/bpnL9Sh0fbk82JtxqPWpSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.15.0",
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/history": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.15.0.tgz",
+      "integrity": "sha512-r+pzR2k/51AL6l8UfXeVe/GWPIeWY1kEOuKx9nsYB9tmAkTF66tTFz33DJIMWBVtAHWN7Dcdv0/yy6q8R6CAUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.15.0",
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/html": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.15.0.tgz",
+      "integrity": "sha512-x/sfGvibwo8b5Vso4ppqNyS/fVve6Rn+TmvP/0eWOaa0I3aOQ57ulfcK6p/GTe+ZaEi8vW64oZPdi8XDgwSRaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.15.0",
+        "@lexical/utils": "0.15.0",
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/link": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.15.0.tgz",
+      "integrity": "sha512-KBV/zWk5FxqZGNcq3IKGBDCcS4t0uteU1osAIG+pefo4waTkOOgibxxEJDop2QR5wtjkYva3Qp0D8ZyJDMMMlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.15.0",
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/list": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.15.0.tgz",
+      "integrity": "sha512-JuF4k7uo4rZFOSZGrmkxo1+sUrwTKNBhhJAiCgtM+6TO90jppxzCFNKur81yPzF1+g4GWLC9gbjzKb52QPb6cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.15.0",
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/mark": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.15.0.tgz",
+      "integrity": "sha512-cdePA98sOJRc4/HHqcOcPBFq4UDwzaFJOK1N1E6XUGcXH1GU8zHtV1ElTgmbsGkyjBRwhR+OqKm9eso1PBOUkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.15.0",
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/markdown": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.15.0.tgz",
+      "integrity": "sha512-wu1EP758l452BovDa7i9ZAeWuFj+YY0bc2mNc08nfZ9GqdGMej1JIguY4CwIROCYVizprL9Ocn0avH1uv9b8fA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/code": "0.15.0",
+        "@lexical/link": "0.15.0",
+        "@lexical/list": "0.15.0",
+        "@lexical/rich-text": "0.15.0",
+        "@lexical/text": "0.15.0",
+        "@lexical/utils": "0.15.0",
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/offset": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.15.0.tgz",
+      "integrity": "sha512-VO1f3m8+RRdRjuXMtCBhi1COVKRC2LhP8AFYxnFlvbV+Waz9R5xB9pqFFUe4RtyqyTLmOUj6+LtsUFhq+23voQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/overflow": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.15.0.tgz",
+      "integrity": "sha512-9qKVCvh9Oka+bzR3th+UWdTEeMZXYy1ZxWbjSxefRMgQxzCvqSuVioK/065gPbvGga9EfvgLLLBDXZm8ISbJQA==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/plain-text": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.15.0.tgz",
+      "integrity": "sha512-yeK466mXb4xaCCJouGzEHQs59fScHxF8Asq0azNyJmkhQWYrU7WdckHf2xj8ItZFFPyj7lvwKRDYnoy4HQD7Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.15.0",
+        "@lexical/selection": "0.15.0",
+        "@lexical/utils": "0.15.0",
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/react": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.15.0.tgz",
+      "integrity": "sha512-TWDp/F9cKwjGreLzIdHKlPUeTn275rR6j1VXrBffNwC5ovxWcKLVRg502eY5xvRQH3lkKQpFgIFbJW4KTvhFsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.15.0",
+        "@lexical/code": "0.15.0",
+        "@lexical/devtools-core": "0.15.0",
+        "@lexical/dragon": "0.15.0",
+        "@lexical/hashtag": "0.15.0",
+        "@lexical/history": "0.15.0",
+        "@lexical/link": "0.15.0",
+        "@lexical/list": "0.15.0",
+        "@lexical/mark": "0.15.0",
+        "@lexical/markdown": "0.15.0",
+        "@lexical/overflow": "0.15.0",
+        "@lexical/plain-text": "0.15.0",
+        "@lexical/rich-text": "0.15.0",
+        "@lexical/selection": "0.15.0",
+        "@lexical/table": "0.15.0",
+        "@lexical/text": "0.15.0",
+        "@lexical/utils": "0.15.0",
+        "@lexical/yjs": "0.15.0",
+        "lexical": "0.15.0",
+        "react-error-boundary": "^3.1.4"
+      },
+      "peerDependencies": {
+        "react": ">=17.x",
+        "react-dom": ">=17.x"
+      }
+    },
+    "node_modules/@lexical/rich-text": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.15.0.tgz",
+      "integrity": "sha512-76tXh/eeEOHl91HpFEXCc/tUiLrsa9RcSyvCzRZahk5zqYvQPXma/AUfRzuSMf2kLwDEoauKAVqNFQcbPhqwpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.15.0",
+        "@lexical/selection": "0.15.0",
+        "@lexical/utils": "0.15.0",
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/selection": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.15.0.tgz",
+      "integrity": "sha512-S+AQC6eJiQYSa5zOPuecN85prCT0Bcb8miOdJaE17Zh+vgdUH5gk9I0tEBeG5T7tkSpq6lFiEqs2FZSfaHflbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/table": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.15.0.tgz",
+      "integrity": "sha512-3IRBg8IoIHetqKozRQbJQ2aPyG0ziXZ+lc8TOIAGs6METW/wxntaV+rTNrODanKAgvk2iJTIyfFkYjsqS9+VFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.15.0",
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/text": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.15.0.tgz",
+      "integrity": "sha512-WsAkAt9T1RH1iDrVuWeoRUeMCOAWar5oSFtnQ4m9vhT/zuf5b8efK87GiqCH00ZAn4DGzOuAfyXlMFqBVCQdkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.15.0.tgz",
+      "integrity": "sha512-/6954LDmTcVFgexhy5WOZDa4TxNQOEZNrf8z7TRAFiAQkihcME/GRoq1en5cbXoVNF8jv5AvNyyc7x0MByRJ6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/list": "0.15.0",
+        "@lexical/selection": "0.15.0",
+        "@lexical/table": "0.15.0",
+        "lexical": "0.15.0"
+      }
+    },
+    "node_modules/@lexical/yjs": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.15.0.tgz",
+      "integrity": "sha512-Rf4AIu620Cq90li6GU58gkzlGRdntHP4ZeZrbJ3ToW7vEEnkW6Wl9/HhO647GG4OL5w46M0iWvx1b1b8xjYT1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/offset": "0.15.0",
+        "lexical": "0.15.0"
+      },
+      "peerDependencies": {
+        "yjs": ">=13.5.22"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -5707,6 +5968,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -5879,6 +6151,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lexical": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.15.0.tgz",
+      "integrity": "sha512-/7HrPAmtgsc1F+qpv5bFwoQZ6CbH/w3mPPL2AW5P75/QYrqKz4bhvJrc2jozIX0GxtuT/YUYT7w+1sZMtUWbOg==",
+      "license": "MIT"
+    },
+    "node_modules/lib0": {
+      "version": "0.2.114",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
+      "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lilconfig": {
@@ -6799,6 +7099,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -6883,6 +7192,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {
@@ -9468,6 +9793,24 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.27",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
+      "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@lexical/markdown": "^0.15.0",
     "@lexical/react": "^0.15.0",
     "@lexical/rich-text": "^0.15.0",
+    "@lexical/selection": "^0.15.0",
     "marked": "^12.0.2",
     "pdfjs-dist": "^3.11.174",
     "lexical": "^0.15.0",

--- a/src/components/Notable.jsx
+++ b/src/components/Notable.jsx
@@ -8,7 +8,12 @@ import { ListPlugin } from '@lexical/react/LexicalListPlugin'
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin'
 import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin'
 import { HeadingNode, QuoteNode } from '@lexical/rich-text'
-import { ListItemNode, ListNode } from '@lexical/list'
+import {
+  ListItemNode,
+  ListNode,
+  INSERT_ORDERED_LIST_COMMAND,
+  INSERT_UNORDERED_LIST_COMMAND,
+} from '@lexical/list'
 import { CodeNode, INSERT_CODE_BLOCK_COMMAND } from '@lexical/code'
 import { LinkNode, TOGGLE_LINK_COMMAND } from '@lexical/link'
 import { HorizontalRuleNode, INSERT_HORIZONTAL_RULE_COMMAND } from '@lexical/react/LexicalHorizontalRuleNode'
@@ -17,8 +22,6 @@ import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext
 import {
   FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
-  INSERT_ORDERED_LIST_COMMAND,
-  INSERT_UNORDERED_LIST_COMMAND,
   REDO_COMMAND,
   UNDO_COMMAND,
 } from 'lexical'

--- a/src/components/Notable.jsx
+++ b/src/components/Notable.jsx
@@ -14,12 +14,14 @@ import {
   INSERT_ORDERED_LIST_COMMAND,
   INSERT_UNORDERED_LIST_COMMAND,
 } from '@lexical/list'
-import { CodeNode, INSERT_CODE_BLOCK_COMMAND } from '@lexical/code'
+import { CodeNode, $createCodeNode } from '@lexical/code'
+import { $setBlocksType } from '@lexical/selection'
 import { LinkNode, TOGGLE_LINK_COMMAND } from '@lexical/link'
 import { HorizontalRuleNode, INSERT_HORIZONTAL_RULE_COMMAND } from '@lexical/react/LexicalHorizontalRuleNode'
 import { TRANSFORMERS, $convertToMarkdownString } from '@lexical/markdown'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import {
+  $getSelection,
   FORMAT_ELEMENT_COMMAND,
   FORMAT_TEXT_COMMAND,
   REDO_COMMAND,
@@ -44,6 +46,14 @@ function ToolbarPlugin() {
     const url = window.prompt('Enter URL')
     editor.dispatchCommand(TOGGLE_LINK_COMMAND, url || null)
   }
+  const insertCodeBlock = () => {
+    editor.update(() => {
+      const selection = $getSelection()
+      if (selection) {
+        $setBlocksType(selection, () => $createCodeNode())
+      }
+    })
+  }
   return (
     <div className='flex flex-wrap gap-2 mb-2'>
       <button className={btn} onClick={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold')}>B</button>
@@ -56,7 +66,7 @@ function ToolbarPlugin() {
       <button className={btn} onClick={() => editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND)}>• List</button>
       <button className={btn} onClick={() => editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND)}>1. List</button>
       <button className={btn} onClick={() => editor.dispatchCommand(FORMAT_ELEMENT_COMMAND, 'quote')}>Quote</button>
-      <button className={btn} onClick={() => editor.dispatchCommand(INSERT_CODE_BLOCK_COMMAND)}>Code</button>
+      <button className={btn} onClick={insertCodeBlock}>Code</button>
       <button className={btn} onClick={insertLink}>Link</button>
       <button className={btn} onClick={() => editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND)}>HR</button>
       <button className={btn} onClick={() => editor.dispatchCommand(UNDO_COMMAND)}>Undo</button>


### PR DESCRIPTION
## Summary
- fix Notable editor by importing list insertion commands from `@lexical/list`
- document Lexical list command source in AGENTS and GEMINI guides

## Testing
- `npm test` *(fails: Failed to resolve import "@lexical/react/LexicalComposer")*
- `npm run build` *(fails: Rollup failed to resolve import "@lexical/react/LexicalComposer")*

------
https://chatgpt.com/codex/tasks/task_e_68c2b29fde9c832eb3d9ab6a7e6c86ad