### PR TITLE
feat: add Promptable tool for prompt iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ Features:
 - Filter by failure mode and lever (Write, Select, Compress, Isolate)
 - Search across card content and copy card text or filtered JSON
 
+## Promptable
+- Location: `src/components/Promptable.jsx`
+- Route: `/promptable`
+
+Features:
+- Manage a personal prompt library with metadata (target model, use case) stored locally.
+- Request Gemini to improve a prompt and preview a monochrome diff before accepting changes.
+- Browse and restore saved versions with inline diffs to track iteration history.
+- Run sample inputs against Gemini, copy results, and optionally archive runs to Notable.
+
 ## Notes
 - PictureMe: This tool is based on the Gemini Canvas template created by the Google team, and they shared details in this X post: https://x.com/GeminiApp/status/1963615829708132611
  - Image editing (Gemini): Client calls use the `gemini-2.5-flash-image-preview:generateContent` endpoint with two parts: a text instruction and the input image as `inlineData` (base64). The response may include an `inlineData` image (PNG). For background removal, instruct Gemini to produce a transparent PNG without cropping, and implement simple retries for `429`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@lexical/react": "^0.17.0",
         "@lexical/rich-text": "^0.17.0",
         "@tabler/icons-react": "^3.34.1",
+        "diff-match-patch": "^1.0.5",
         "jsdom": "^24.1.1",
         "lexical": "^0.17.0",
         "marked": "^12.0.2",
@@ -5557,6 +5558,12 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@lexical/react": "^0.17.0",
     "@lexical/rich-text": "^0.17.0",
     "@tabler/icons-react": "^3.34.1",
+    "diff-match-patch": "^1.0.5",
     "jsdom": "^24.1.1",
     "lexical": "^0.17.0",
     "marked": "^12.0.2",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -25,6 +25,7 @@
   <url><loc>https://toolbox.nurcholis.art/mermaid-validator</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://toolbox.nurcholis.art/token-counter</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://toolbox.nurcholis.art/notable</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
+  <url><loc>https://toolbox.nurcholis.art/promptable</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://toolbox.nurcholis.art/chromatic-tuner</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
   <url><loc>https://toolbox.nurcholis.art/settings</loc><changefreq>monthly</changefreq><priority>0.2</priority></url>
   <url><loc>https://toolbox.nurcholis.art/about</loc><changefreq>monthly</changefreq><priority>0.3</priority></url>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import LockfileScanner from './components/LockfileScanner.jsx'
 import MermaidValidator from './components/MermaidValidator.jsx'
 import TokenCounter from './components/TokenCounter.jsx'
 import Notable from './components/Notable.jsx'
+import Promptable from './components/Promptable.jsx'
 import ChromaticTuner from './components/ChromaticTuner.jsx'
 import GemfileScanner from './components/GemfileScanner.jsx'
 import GoSumScanner from './components/GoSumScanner.jsx'
@@ -47,6 +48,7 @@ const tools = [
   { name: 'Mermaid Validator', description: 'Validate a Mermaid diagram string', link: '/mermaid-validator' },
   { name: 'Token Counter', description: 'Count tokens with layered CDN fallbacks', link: '/token-counter' },
   { name: 'Notable', description: 'Local notes with a rich-text editor', link: '/notable' },
+  { name: 'Promptable', description: 'Iterate on prompts with Gemini previews', link: '/promptable' },
   { name: 'Chromatic Tuner', description: 'Tune instruments via microphone', link: '/chromatic-tuner' },
   {
     name: 'Propose new tool',
@@ -122,6 +124,7 @@ export default function App() {
   const isHillChart = useMemo(() => basePath === '/hill-chart', [basePath])
   const isShapeUpInfographic = useMemo(() => basePath === '/shape-up', [basePath])
   const isNotable = useMemo(() => basePath === '/notable', [basePath])
+  const isPromptable = useMemo(() => basePath === '/promptable', [basePath])
   const isChromaticTuner = useMemo(() => basePath === '/chromatic-tuner', [basePath])
   
   const isSettings = useMemo(() => basePath === '/settings', [basePath])
@@ -603,6 +606,37 @@ export default function App() {
           </div>
         </div>
         <TokenCounter />
+      </div>
+    )
+  }
+
+  if (isPromptable) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-6">
+          <div className="flex items-center justify-between">
+            <a
+              href="/"
+              className="inline-flex items-center gap-2 text-sm bg-white text-black border-2 border-black rounded-lg px-3 py-1 hover:bg-gray-100 shadow-sm"
+            >
+              <IconArrowLeft size={18} stroke={2} />
+              Back to tools
+            </a>
+            <div className="flex items-center gap-2">
+              <InstallPrompt />
+              <a
+                href="/settings"
+                className="inline-flex items-center gap-2 text-sm bg-white text-black border-2 border-black rounded-lg px-3 py-1 hover:bg-gray-100 shadow-sm"
+              >
+                <IconSettings size={16} stroke={2} />
+                Edit Config
+              </a>
+            </div>
+          </div>
+        </div>
+        <div className="px-4 sm:px-6 lg:px-8 pb-8 mt-6">
+          <Promptable />
+        </div>
       </div>
     )
   }

--- a/src/components/Promptable.jsx
+++ b/src/components/Promptable.jsx
@@ -1,0 +1,753 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  IconPlus,
+  IconCopy,
+  IconWand,
+  IconX,
+  IconDeviceFloppy,
+  IconHistory,
+  IconArrowsDiff,
+  IconPlayerPlay,
+  IconDownload,
+  IconRestore,
+  IconSearch,
+} from '@tabler/icons-react'
+import DiffMatchPatch from 'diff-match-patch'
+import { getApiKey } from '../lib/config.js'
+
+const STORAGE_KEY = 'promptable:prompts'
+
+const defaultModelOptions = [
+  'gemini-2.0-flash',
+  'gemini-2.0-pro',
+  'gemini-1.5-pro',
+  'gemini-1.5-flash',
+  'gemini-exp-1206',
+]
+
+const emptyPrompt = () => ({
+  id: crypto.randomUUID(),
+  title: 'Untitled prompt',
+  content: '',
+  model: 'gemini-2.0-flash',
+  useCase: '',
+  updated: Date.now(),
+  lastTestedAt: null,
+  history: [],
+  tests: [],
+})
+
+const migratePrompt = (prompt) => {
+  if (!prompt || typeof prompt !== 'object') return emptyPrompt()
+  return {
+    ...emptyPrompt(),
+    ...prompt,
+    history: Array.isArray(prompt.history) ? prompt.history : [],
+    tests: Array.isArray(prompt.tests) ? prompt.tests : [],
+  }
+}
+
+const diffEngine = new DiffMatchPatch()
+
+const buildDiff = (original, draft) => {
+  const diff = diffEngine.diff_main(original || '', draft || '')
+  diffEngine.diff_cleanupSemantic(diff)
+  return diff
+}
+
+const renderDiff = (diff) =>
+  diff.map(([op, text], index) => {
+    const key = `${op}-${index}`
+    const classes =
+      op === 1
+        ? 'bg-gray-200 text-gray-900 px-1 py-0.5 rounded'
+        : op === -1
+          ? 'bg-gray-100 line-through text-gray-600 px-1 py-0.5 rounded'
+          : 'text-gray-800'
+    const segments = text.split('\n')
+    return (
+      <span key={key} className={`inline ${classes}`}>
+        {segments.map((segment, i) => (
+          <React.Fragment key={`${key}-${i}`}>
+            {segment}
+            {i < segments.length - 1 ? <br /> : null}
+          </React.Fragment>
+        ))}
+      </span>
+    )
+  })
+
+const summarise = (text) => {
+  if (!text) return 'Empty prompt'
+  const firstLine = text.split('\n').find((line) => line.trim()) || text
+  return firstLine.length > 140 ? `${firstLine.slice(0, 137)}...` : firstLine
+}
+
+export default function Promptable() {
+  const [prompts, setPrompts] = useState(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (!stored) return [emptyPrompt()]
+      const parsed = JSON.parse(stored)
+      if (!Array.isArray(parsed) || !parsed.length) return [emptyPrompt()]
+      return parsed.map(migratePrompt)
+    } catch (error) {
+      console.error('Failed to load stored prompts', error)
+      return [emptyPrompt()]
+    }
+  })
+  const [currentId, setCurrentId] = useState(() => prompts[0]?.id)
+  const [filter, setFilter] = useState('')
+  const [editorState, setEditorState] = useState(() => prompts[0])
+  const [isImproving, setIsImproving] = useState(false)
+  const [improveError, setImproveError] = useState('')
+  const [improvedDraft, setImprovedDraft] = useState('')
+  const [diff, setDiff] = useState([])
+  const improveDialogRef = useRef(null)
+  const [selectedHistoryId, setSelectedHistoryId] = useState(null)
+  const [historyDiff, setHistoryDiff] = useState([])
+  const [isTesting, setIsTesting] = useState(false)
+  const [testInput, setTestInput] = useState('')
+  const [testOutput, setTestOutput] = useState('')
+  const [testError, setTestError] = useState('')
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prompts))
+  }, [prompts])
+
+  useEffect(() => {
+    const next = prompts.find((item) => item.id === currentId)
+    if (next) {
+      setEditorState(next)
+    }
+  }, [currentId, prompts])
+
+  const persist = (updater) => {
+    setPrompts((prev) => {
+      const next = updater(prev.map(migratePrompt))
+      return next
+    })
+  }
+
+  const currentPrompt = useMemo(
+    () => prompts.find((item) => item.id === currentId) || prompts[0],
+    [currentId, prompts],
+  )
+
+  const filteredPrompts = useMemo(() => {
+    if (!filter.trim()) return prompts
+    const q = filter.toLowerCase()
+    return prompts.filter((prompt) =>
+      prompt.title.toLowerCase().includes(q) || prompt.useCase.toLowerCase().includes(q),
+    )
+  }, [filter, prompts])
+
+  const updateEditorField = (field, value) => {
+    setEditorState((prev) => ({ ...prev, [field]: value }))
+  }
+
+  const addSnapshot = (prompt, content) => {
+    const entry = {
+      id: crypto.randomUUID(),
+      content,
+      createdAt: Date.now(),
+      summary: summarise(content),
+    }
+    const nextHistory = [entry, ...(prompt.history || [])].slice(0, 20)
+    return { ...prompt, history: nextHistory }
+  }
+
+  const handleSavePrompt = () => {
+    if (!currentPrompt) return
+    persist((prev) =>
+      prev.map((item) => {
+        if (item.id !== currentPrompt.id) return item
+        const merged = {
+          ...item,
+          title: editorState.title,
+          content: editorState.content,
+          model: editorState.model,
+          useCase: editorState.useCase,
+          updated: Date.now(),
+        }
+        return addSnapshot(merged, editorState.content)
+      }),
+    )
+  }
+
+  const createPrompt = () => {
+    const prompt = emptyPrompt()
+    setPrompts((prev) => {
+      const next = [prompt, ...prev]
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+      return next
+    })
+    setCurrentId(prompt.id)
+    setEditorState(prompt)
+  }
+
+  const duplicatePrompt = (id) => {
+    const source = prompts.find((item) => item.id === id)
+    if (!source) return
+    const dup = {
+      ...source,
+      id: crypto.randomUUID(),
+      title: `${source.title} copy`,
+      updated: Date.now(),
+      history: [...(source.history || [])],
+      tests: [...(source.tests || [])],
+    }
+    persist((prev) => [dup, ...prev])
+    setCurrentId(dup.id)
+  }
+
+  const deletePrompt = (id) => {
+    if (!window.confirm('Delete this prompt?')) return
+    persist((prev) => {
+      const next = prev.filter((item) => item.id !== id)
+      if (!next.length) {
+        const fresh = emptyPrompt()
+        setCurrentId(fresh.id)
+        return [fresh]
+      }
+      if (currentId === id) {
+        setCurrentId(next[0].id)
+      }
+      return next
+    })
+  }
+
+  const handleImprovePrompt = async () => {
+    setImproveError('')
+    if (!currentPrompt) return
+    const apiKey = getApiKey()
+    if (!apiKey) {
+      setImproveError('API key not set. Open Settings to add your Gemini key.')
+      return
+    }
+    setIsImproving(true)
+    try {
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=${apiKey}`
+      const payload = {
+        systemInstruction: {
+          role: 'system',
+          parts: [
+            {
+              text: 'You improve prompts for large language models. Rewrite the provided prompt to be clearer, more specific, and actionable without changing its intent. Respond with the improved prompt only.',
+            },
+          ],
+        },
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              {
+                text: `Prompt title: ${currentPrompt.title}\nUse case: ${currentPrompt.useCase}\n---\n${editorState.content}`,
+              },
+            ],
+          },
+        ],
+      }
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!resp.ok) {
+        let message = `Request failed ${resp.status}`
+        try {
+          const err = await resp.json()
+          message = err.error?.message || message
+        } catch {}
+        throw new Error(message)
+      }
+      const data = await resp.json()
+      const candidate = data.candidates?.[0]
+      const text = candidate?.content?.parts?.map((part) => part.text).join('').trim()
+      if (!text) throw new Error('Gemini response did not include text content.')
+      setImprovedDraft(text)
+      setDiff(buildDiff(editorState.content, text))
+      const dialog = improveDialogRef.current
+      if (dialog && !dialog.open) dialog.showModal()
+    } catch (error) {
+      console.error(error)
+      setImproveError(error.message || 'Failed to improve prompt.')
+    } finally {
+      setIsImproving(false)
+    }
+  }
+
+  const closeImproveDialog = () => {
+    const dialog = improveDialogRef.current
+    if (dialog?.open) dialog.close()
+    setImprovedDraft('')
+    setDiff([])
+  }
+
+  const acceptImprovement = () => {
+    if (!improvedDraft || !currentPrompt) return
+    persist((prev) =>
+      prev.map((item) => {
+        if (item.id !== currentPrompt.id) return item
+        const updatedPrompt = {
+          ...item,
+          content: improvedDraft,
+          updated: Date.now(),
+        }
+        return addSnapshot(updatedPrompt, improvedDraft)
+      }),
+    )
+    setEditorState((prev) => ({ ...prev, content: improvedDraft }))
+    closeImproveDialog()
+  }
+
+  const copyImprovedDraft = async () => {
+    if (!improvedDraft) return
+    try {
+      await navigator.clipboard.writeText(improvedDraft)
+    } catch (error) {
+      console.error('Failed to copy', error)
+    }
+  }
+
+  const selectHistory = (historyId) => {
+    if (!currentPrompt) return
+    setSelectedHistoryId(historyId)
+    const entry = currentPrompt.history.find((item) => item.id === historyId)
+    if (!entry) {
+      setHistoryDiff([])
+      return
+    }
+    setHistoryDiff(buildDiff(entry.content, editorState.content))
+  }
+
+  const restoreHistory = (historyId) => {
+    if (!currentPrompt) return
+    const entry = currentPrompt.history.find((item) => item.id === historyId)
+    if (!entry) return
+    if (!window.confirm('Restore this version? This will replace the current editor content.')) return
+    setEditorState((prev) => ({ ...prev, content: entry.content }))
+    persist((prev) =>
+      prev.map((item) => {
+        if (item.id !== currentPrompt.id) return item
+        const restored = {
+          ...item,
+          content: entry.content,
+          updated: Date.now(),
+        }
+        return addSnapshot(restored, entry.content)
+      }),
+    )
+  }
+
+  const handleRunTest = async () => {
+    setTestError('')
+    setTestOutput('')
+    if (!currentPrompt) return
+    const apiKey = getApiKey()
+    if (!apiKey) {
+      setTestError('API key not set. Open Settings to add your Gemini key.')
+      return
+    }
+    if (!testInput.trim()) {
+      setTestError('Provide a sample input before running the test.')
+      return
+    }
+    setIsTesting(true)
+    try {
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${currentPrompt.model || 'gemini-2.0-flash'}:generateContent?key=${apiKey}`
+      const payload = {
+        systemInstruction: {
+          role: 'system',
+          parts: [
+            {
+              text: 'You are evaluating a prompt. Follow the prompt instructions exactly when responding to the provided sample input.',
+            },
+          ],
+        },
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              {
+                text: `PROMPT:\n${editorState.content}\n\nSAMPLE INPUT:\n${testInput}`,
+              },
+            ],
+          },
+        ],
+      }
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      if (!resp.ok) {
+        let message = `Request failed ${resp.status}`
+        try {
+          const err = await resp.json()
+          message = err.error?.message || message
+        } catch {}
+        throw new Error(message)
+      }
+      const data = await resp.json()
+      const candidate = data.candidates?.[0]
+      const text = candidate?.content?.parts?.map((part) => part.text).join('').trim()
+      if (!text) throw new Error('Gemini response did not include text output.')
+      setTestOutput(text)
+      const testEntry = {
+        id: crypto.randomUUID(),
+        input: testInput,
+        output: text,
+        createdAt: Date.now(),
+      }
+      persist((prev) =>
+        prev.map((item) => {
+          if (item.id !== currentPrompt.id) return item
+          return {
+            ...item,
+            lastTestedAt: Date.now(),
+            tests: [testEntry, ...(item.tests || [])].slice(0, 20),
+          }
+        }),
+      )
+    } catch (error) {
+      console.error(error)
+      setTestError(error.message || 'Failed to run prompt test.')
+    } finally {
+      setIsTesting(false)
+    }
+  }
+
+  const copyTestOutput = async () => {
+    if (!testOutput) return
+    try {
+      await navigator.clipboard.writeText(testOutput)
+    } catch (error) {
+      console.error('Failed to copy test output', error)
+    }
+  }
+
+  const saveTestAsNote = () => {
+    if (!testOutput) return
+    try {
+      const stored = localStorage.getItem('notable:notes')
+      const notes = stored ? JSON.parse(stored) : []
+      const id = crypto.randomUUID()
+      const note = {
+        id,
+        title: `${editorState.title} test ${new Date().toLocaleString()}`,
+        content: `# Prompt test result\n\n**Prompt:** ${editorState.title}\n\n**Sample input**\n\n${testInput}\n\n**Output**\n\n${testOutput}`,
+        updated: Date.now(),
+      }
+      const nextNotes = Array.isArray(notes) && notes.length ? [note, ...notes] : [note]
+      localStorage.setItem('notable:notes', JSON.stringify(nextNotes))
+      window.dispatchEvent(new Event('storage'))
+    } catch (error) {
+      console.error('Failed to save note', error)
+    }
+  }
+
+  return (
+    <div className='min-h-screen bg-gray-50 py-6'>
+      <div className='mx-auto max-w-6xl px-4 sm:px-6 lg:px-8'>
+        <div className='bg-white border-2 border-black rounded-xl shadow-md p-6'>
+          <header className='flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between'>
+            <div>
+              <h1 className='text-3xl font-bold text-gray-900'>Promptable</h1>
+              <p className='text-gray-600 mt-1'>Create, iterate, and test prompts with Gemini-powered previews.</p>
+            </div>
+            <div className='flex flex-wrap gap-2'>
+              <button
+                type='button'
+                onClick={createPrompt}
+                className='inline-flex items-center gap-2 bg-black text-white rounded-lg px-3 py-2 text-sm hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-black'
+              >
+                <IconPlus size={16} />
+                New prompt
+              </button>
+              <button
+                type='button'
+                onClick={handleSavePrompt}
+                className='inline-flex items-center gap-2 bg-white text-black border-2 border-black rounded-lg px-3 py-2 text-sm hover:bg-gray-100 focus:outline-none'
+              >
+                <IconDeviceFloppy size={16} />
+                Save changes
+              </button>
+              <button
+                type='button'
+                onClick={handleImprovePrompt}
+                className='inline-flex items-center gap-2 bg-white text-black border-2 border-black rounded-lg px-3 py-2 text-sm hover:bg-gray-100 focus:outline-none'
+                disabled={isImproving}
+              >
+                <IconWand size={16} />
+                {isImproving ? 'Improving…' : 'Improve prompt'}
+              </button>
+            </div>
+          </header>
+
+          {improveError ? (
+            <p className='mt-4 text-sm text-gray-700'>{improveError}</p>
+          ) : null}
+
+          <div className='mt-6 grid gap-6 lg:grid-cols-[260px_1fr]'>
+            <aside className='bg-gray-100 border-2 border-black rounded-lg p-4 space-y-4'>
+              <div className='relative'>
+                <IconSearch size={16} className='absolute left-3 top-1/2 -translate-y-1/2 text-gray-600' />
+                <input
+                  type='search'
+                  value={filter}
+                  onChange={(event) => setFilter(event.target.value)}
+                  placeholder='Search prompts'
+                  className='w-full bg-white border-2 border-black rounded-lg pl-9 pr-3 py-2 text-sm focus:outline-none'
+                />
+              </div>
+              <ul className='space-y-2 max-h-[420px] overflow-y-auto pr-1'>
+                {filteredPrompts.map((prompt) => (
+                  <li key={prompt.id}>
+                    <button
+                      type='button'
+                      onClick={() => setCurrentId(prompt.id)}
+                      className={`w-full text-left px-3 py-2 rounded-lg border-2 ${prompt.id === currentId ? 'border-black bg-white shadow-sm' : 'border-transparent bg-gray-200 hover:bg-gray-300'}`}
+                    >
+                      <p className='font-medium text-sm text-gray-900 truncate'>{prompt.title}</p>
+                      <p className='text-xs text-gray-700 truncate'>{prompt.useCase || 'No use case'}</p>
+                      <div className='mt-1 flex items-center gap-2 text-[11px] text-gray-600'>
+                        <span>{prompt.model}</span>
+                        {prompt.lastTestedAt ? <span>Tested {new Date(prompt.lastTestedAt).toLocaleString()}</span> : null}
+                      </div>
+                    </button>
+                    <div className='mt-1 flex items-center gap-2'>
+                      <button
+                        type='button'
+                        className='flex-1 bg-white border-2 border-black rounded-lg px-2 py-1 text-xs hover:bg-gray-100'
+                        onClick={() => duplicatePrompt(prompt.id)}
+                      >
+                        Duplicate
+                      </button>
+                      <button
+                        type='button'
+                        className='flex-1 bg-white border-2 border-black rounded-lg px-2 py-1 text-xs hover:bg-gray-100'
+                        onClick={() => deletePrompt(prompt.id)}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </aside>
+
+            <main className='space-y-6'>
+              <section className='bg-white border-2 border-black rounded-lg p-4 space-y-4'>
+                <div>
+                  <label className='block text-sm font-medium text-gray-800 mb-1' htmlFor='prompt-title'>Title</label>
+                  <input
+                    id='prompt-title'
+                    type='text'
+                    value={editorState?.title || ''}
+                    onChange={(event) => updateEditorField('title', event.target.value)}
+                    className='w-full bg-white border-2 border-black rounded-lg px-3 py-2 focus:outline-none'
+                  />
+                </div>
+                <div className='grid gap-4 sm:grid-cols-2'>
+                  <div>
+                    <label className='block text-sm font-medium text-gray-800 mb-1' htmlFor='prompt-model'>Target model</label>
+                    <select
+                      id='prompt-model'
+                      value={editorState?.model || ''}
+                      onChange={(event) => updateEditorField('model', event.target.value)}
+                      className='w-full bg-white border-2 border-black rounded-lg px-3 py-2 focus:outline-none'
+                    >
+                      {defaultModelOptions.map((model) => (
+                        <option key={model} value={model}>{model}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div>
+                    <label className='block text-sm font-medium text-gray-800 mb-1' htmlFor='prompt-usecase'>Use case</label>
+                    <input
+                      id='prompt-usecase'
+                      type='text'
+                      value={editorState?.useCase || ''}
+                      onChange={(event) => updateEditorField('useCase', event.target.value)}
+                      className='w-full bg-white border-2 border-black rounded-lg px-3 py-2 focus:outline-none'
+                    />
+                  </div>
+                </div>
+                <div>
+                  <label className='block text-sm font-medium text-gray-800 mb-1' htmlFor='prompt-content'>Prompt</label>
+                  <textarea
+                    id='prompt-content'
+                    value={editorState?.content || ''}
+                    onChange={(event) => updateEditorField('content', event.target.value)}
+                    rows={14}
+                    className='w-full bg-white border-2 border-black rounded-lg px-3 py-2 focus:outline-none leading-relaxed'
+                  />
+                </div>
+              </section>
+
+              <section className='bg-white border-2 border-black rounded-lg p-4'>
+                <div className='flex items-center justify-between'>
+                  <div>
+                    <h2 className='text-lg font-semibold text-gray-900'>History</h2>
+                    <p className='text-sm text-gray-600'>Snapshots are created when you save or accept Gemini suggestions.</p>
+                  </div>
+                  <IconHistory size={20} className='text-gray-700' />
+                </div>
+                <div className='mt-4 grid gap-4 lg:grid-cols-[220px_1fr]'>
+                  <ul className='space-y-2 max-h-64 overflow-y-auto pr-1'>
+                    {currentPrompt?.history?.length ? (
+                      currentPrompt.history.map((entry) => (
+                        <li key={entry.id}>
+                          <button
+                            type='button'
+                            onClick={() => selectHistory(entry.id)}
+                            className={`w-full text-left px-3 py-2 rounded-lg border-2 ${entry.id === selectedHistoryId ? 'border-black bg-white shadow-sm' : 'border-transparent bg-gray-100 hover:bg-gray-200'}`}
+                          >
+                            <p className='text-sm font-medium text-gray-900'>{new Date(entry.createdAt).toLocaleString()}</p>
+                            <p className='text-xs text-gray-700'>{entry.summary}</p>
+                          </button>
+                          <button
+                            type='button'
+                            onClick={() => restoreHistory(entry.id)}
+                            className='mt-2 inline-flex items-center gap-2 bg-white border-2 border-black rounded-lg px-2 py-1 text-xs hover:bg-gray-100'
+                          >
+                            <IconRestore size={14} />
+                            Restore
+                          </button>
+                        </li>
+                      ))
+                    ) : (
+                      <li className='text-sm text-gray-700'>No history yet.</li>
+                    )}
+                  </ul>
+                  <div className='border-2 border-black rounded-lg p-3 bg-gray-50 min-h-[200px]'>
+                    <h3 className='text-sm font-semibold text-gray-800 mb-2 flex items-center gap-2'>
+                      <IconArrowsDiff size={16} />
+                      Differences from current editor
+                    </h3>
+                    <div className='text-sm text-gray-800 whitespace-pre-wrap break-words leading-relaxed'>
+                      {historyDiff.length ? renderDiff(historyDiff) : 'Select a snapshot to compare with the current content.'}
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              <section className='bg-white border-2 border-black rounded-lg p-4 space-y-4'>
+                <div className='flex items-center justify-between'>
+                  <div>
+                    <h2 className='text-lg font-semibold text-gray-900'>Test prompt</h2>
+                    <p className='text-sm text-gray-600'>Send a sample input through Gemini using the selected model.</p>
+                  </div>
+                  <IconPlayerPlay size={20} className='text-gray-700' />
+                </div>
+                <div>
+                  <label className='block text-sm font-medium text-gray-800 mb-1' htmlFor='test-input'>Sample input</label>
+                  <textarea
+                    id='test-input'
+                    value={testInput}
+                    onChange={(event) => setTestInput(event.target.value)}
+                    rows={6}
+                    className='w-full bg-white border-2 border-black rounded-lg px-3 py-2 focus:outline-none'
+                  />
+                </div>
+                {testError ? <p className='text-sm text-gray-700'>{testError}</p> : null}
+                <div className='flex flex-wrap gap-2'>
+                  <button
+                    type='button'
+                    onClick={handleRunTest}
+                    disabled={isTesting}
+                    className='inline-flex items-center gap-2 bg-black text-white rounded-lg px-3 py-2 text-sm hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-black'
+                  >
+                    <IconPlayerPlay size={16} />
+                    {isTesting ? 'Running…' : 'Run test'}
+                  </button>
+                  <button
+                    type='button'
+                    onClick={copyTestOutput}
+                    className='inline-flex items-center gap-2 bg-white border-2 border-black text-black rounded-lg px-3 py-2 text-sm hover:bg-gray-100 focus:outline-none'
+                  >
+                    <IconCopy size={16} />
+                    Copy result
+                  </button>
+                  <button
+                    type='button'
+                    onClick={saveTestAsNote}
+                    className='inline-flex items-center gap-2 bg-white border-2 border-black text-black rounded-lg px-3 py-2 text-sm hover:bg-gray-100 focus:outline-none'
+                  >
+                    <IconDownload size={16} />
+                    Save result to Notable
+                  </button>
+                </div>
+                <div className='border-2 border-black rounded-lg p-3 bg-gray-50 min-h-[180px] whitespace-pre-wrap text-sm text-gray-900'>
+                  {testOutput || 'Test output will appear here after you run Gemini.'}
+                </div>
+                <div>
+                  <h3 className='text-sm font-semibold text-gray-800 mb-2'>Recent test runs</h3>
+                  <ul className='space-y-2 max-h-48 overflow-y-auto pr-1 text-sm text-gray-700'>
+                    {currentPrompt?.tests?.length ? (
+                      currentPrompt.tests.map((item) => (
+                        <li key={item.id} className='bg-gray-100 border-2 border-black rounded-lg p-3'>
+                          <p className='text-xs text-gray-600 mb-1'>{new Date(item.createdAt).toLocaleString()}</p>
+                          <p className='font-medium text-gray-900 mb-1'>Sample input</p>
+                          <p className='mb-2 whitespace-pre-wrap'>{item.input}</p>
+                          <p className='font-medium text-gray-900 mb-1'>Output</p>
+                          <p className='whitespace-pre-wrap'>{item.output}</p>
+                        </li>
+                      ))
+                    ) : (
+                      <li className='text-sm text-gray-700'>No tests recorded yet.</li>
+                    )}
+                  </ul>
+                </div>
+              </section>
+            </main>
+          </div>
+        </div>
+      </div>
+
+      <dialog ref={improveDialogRef} className='rounded-lg border-2 border-black bg-white p-0 max-w-2xl w-full'>
+        <form method='dialog'>
+          <header className='flex items-center justify-between px-4 py-3 border-b-2 border-black'>
+            <h2 className='text-lg font-semibold text-gray-900 flex items-center gap-2'>
+              <IconArrowsDiff size={18} />
+              Gemini preview
+            </h2>
+            <button type='button' onClick={closeImproveDialog} className='text-gray-700 hover:text-black'>
+              <IconX size={18} />
+            </button>
+          </header>
+          <div className='px-4 py-4 space-y-4'>
+            <div className='border-2 border-black rounded-lg p-3 bg-gray-50 max-h-[320px] overflow-y-auto text-sm whitespace-pre-wrap leading-relaxed text-gray-900'>
+              {diff.length ? renderDiff(diff) : 'No differences to display.'}
+            </div>
+            <div className='flex flex-wrap gap-2'>
+              <button
+                type='button'
+                onClick={acceptImprovement}
+                className='inline-flex items-center gap-2 bg-black text-white rounded-lg px-3 py-2 text-sm hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-black'
+              >
+                Accept changes
+              </button>
+              <button
+                type='button'
+                onClick={copyImprovedDraft}
+                className='inline-flex items-center gap-2 bg-white border-2 border-black rounded-lg px-3 py-2 text-sm hover:bg-gray-100 focus:outline-none'
+              >
+                <IconCopy size={16} />
+                Copy preview
+              </button>
+              <button
+                type='button'
+                onClick={closeImproveDialog}
+                className='inline-flex items-center gap-2 bg-white border-2 border-black rounded-lg px-3 py-2 text-sm hover:bg-gray-100 focus:outline-none'
+              >
+                Discard
+              </button>
+            </div>
+          </div>
+        </form>
+      </dialog>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add the Promptable tool with prompt library management, Gemini-powered improvement previews, history diffs, and an inline test runner
- register the new route in the toolbox navigation and update the sitemap and documentation
- install diff-match-patch to render monochrome diff previews for Gemini suggestions and history snapshots

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d643923d00832e8ffe041330d6213f