### PR TITLE
feat: upgrade SQL editor to CodeMirror v6

### DIFF
--- a/src/components/SqlEditor.jsx
+++ b/src/components/SqlEditor.jsx
@@ -3,8 +3,23 @@ import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
 } from 'react'
+import { Compartment, EditorState } from '@codemirror/state'
+import {
+  EditorView,
+  drawSelection,
+  highlightActiveLine,
+  highlightActiveLineGutter,
+  keymap,
+  lineNumbers,
+  placeholder as cmPlaceholder,
+} from '@codemirror/view'
+import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands'
+import { autocompletion } from '@codemirror/autocomplete'
+import { indentUnit } from '@codemirror/language'
+import { sql } from '@codemirror/lang-sql'
 
 const SqlEditor = forwardRef(function SqlEditor({
   value = '',
@@ -16,138 +31,286 @@ const SqlEditor = forwardRef(function SqlEditor({
   onCursorChange,
   onFocus,
   wrap = false,
-  extraExtensions: _extraExtensions = [],
+  extraExtensions: extraExtensionsProp = [],
 }, ref) {
-  const textareaRef = useRef(null)
+  const containerRef = useRef(null)
+  const viewRef = useRef(null)
+  const wrapCompartment = useMemo(() => new Compartment(), [])
+  const placeholderCompartment = useMemo(() => new Compartment(), [])
+  const extraExtensionsCompartment = useMemo(() => new Compartment(), [])
 
-  const emitSelectionState = useCallback(() => {
-    const textarea = textareaRef.current
-    if (!textarea) return
-    const selectionStart = textarea.selectionStart ?? 0
-    const selectionEnd = textarea.selectionEnd ?? selectionStart
-    const currentValue = textarea.value ?? ''
-    if (onSelectionChange) {
-      const selected = selectionStart === selectionEnd
-        ? ''
-        : currentValue.slice(selectionStart, selectionEnd)
-      onSelectionChange(selected)
+  const onChangeRef = useRef(onChange)
+  const onRunRef = useRef(onRun)
+  const onRunSelectionRef = useRef(onRunSelection)
+  const onSelectionChangeRef = useRef(onSelectionChange)
+  const onCursorChangeRef = useRef(onCursorChange)
+  const onFocusRef = useRef(onFocus)
+
+  useEffect(() => {
+    onChangeRef.current = onChange
+  }, [onChange])
+  useEffect(() => {
+    onRunRef.current = onRun
+  }, [onRun])
+  useEffect(() => {
+    onRunSelectionRef.current = onRunSelection
+  }, [onRunSelection])
+  useEffect(() => {
+    onSelectionChangeRef.current = onSelectionChange
+  }, [onSelectionChange])
+  useEffect(() => {
+    onCursorChangeRef.current = onCursorChange
+  }, [onCursorChange])
+  useEffect(() => {
+    onFocusRef.current = onFocus
+  }, [onFocus])
+
+  const runKeymap = useMemo(
+    () =>
+      keymap.of([
+        {
+          key: 'Shift-Mod-Enter',
+          run: () => {
+            if (onRunSelectionRef.current) {
+              onRunSelectionRef.current()
+              return true
+            }
+            if (onRunRef.current) {
+              onRunRef.current()
+              return true
+            }
+            return false
+          },
+        },
+        {
+          key: 'Mod-Enter',
+          run: () => {
+            if (onRunRef.current) {
+              onRunRef.current()
+              return true
+            }
+            return false
+          },
+        },
+        indentWithTab,
+      ]),
+    [],
+  )
+
+  const updateListener = useMemo(
+    () =>
+      EditorView.updateListener.of((update) => {
+        if (update.focusChanged && update.view.hasFocus) {
+          if (onFocusRef.current) onFocusRef.current()
+        }
+
+        if (update.docChanged) {
+          if (onChangeRef.current) {
+            onChangeRef.current(update.state.doc.toString())
+          }
+        }
+
+        if (update.docChanged || update.selectionSet) {
+          const { main } = update.state.selection
+          if (onSelectionChangeRef.current) {
+            if (main.empty) {
+              onSelectionChangeRef.current('')
+            } else {
+              onSelectionChangeRef.current(update.state.sliceDoc(main.from, main.to))
+            }
+          }
+          if (onCursorChangeRef.current) {
+            onCursorChangeRef.current({ head: main.head, anchor: main.anchor })
+          }
+        }
+      }),
+    [],
+  )
+
+  const baseTheme = useMemo(
+    () =>
+      EditorView.theme({
+        '&': {
+          height: '100%',
+          backgroundColor: 'transparent',
+          color: '#111827',
+        },
+        '.cm-content': {
+          fontFamily:
+            'ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+          fontSize: '0.875rem',
+          lineHeight: '1.5rem',
+          padding: '0.75rem',
+        },
+        '.cm-line': {
+          padding: '0 0.25rem',
+        },
+        '.cm-scroller': {
+          overflow: 'auto',
+        },
+        '.cm-gutters': {
+          backgroundColor: 'transparent',
+          color: '#6b7280',
+          border: 'none',
+        },
+        '.cm-activeLineGutter': {
+          backgroundColor: '#f3f4f6',
+        },
+        '.cm-activeLine': {
+          backgroundColor: '#f9fafb',
+        },
+        '.cm-selectionBackground, &.cm-focused .cm-selectionBackground': {
+          backgroundColor: '#11182726',
+        },
+        '&.cm-editor.cm-focused': {
+          outline: 'none',
+        },
+      }),
+    [],
+  )
+
+  useEffect(() => {
+    if (!containerRef.current || viewRef.current) return
+
+    const startState = EditorState.create({
+      doc: value,
+      extensions: [
+        lineNumbers(),
+        highlightActiveLine(),
+        highlightActiveLineGutter(),
+        drawSelection(),
+        history(),
+        autocompletion(),
+        indentUnit.of('  '),
+        EditorState.tabSize.of(2),
+        sql(),
+        baseTheme,
+        EditorView.contentAttributes.of({
+          'aria-label': 'SQL editor',
+          spellcheck: 'false',
+          autocorrect: 'off',
+          autocomplete: 'off',
+          autocapitalize: 'none',
+        }),
+        runKeymap,
+        keymap.of([...historyKeymap, ...defaultKeymap]),
+        updateListener,
+        wrapCompartment.of(wrap ? EditorView.lineWrapping : []),
+        placeholderCompartment.of(placeholder ? cmPlaceholder(placeholder) : []),
+        extraExtensionsCompartment.of(extraExtensionsProp || []),
+      ],
+    })
+
+    const view = new EditorView({
+      state: startState,
+      parent: containerRef.current,
+    })
+
+    viewRef.current = view
+
+    if (onSelectionChangeRef.current) {
+      onSelectionChangeRef.current('')
     }
-    if (onCursorChange) {
-      onCursorChange({ head: selectionEnd, anchor: selectionStart })
+    if (onCursorChangeRef.current) {
+      const { main } = view.state.selection
+      onCursorChangeRef.current({ head: main.head, anchor: main.anchor })
     }
-  }, [onCursorChange, onSelectionChange])
+
+    return () => {
+      view.destroy()
+      viewRef.current = null
+    }
+  }, [
+    baseTheme,
+    extraExtensionsCompartment,
+    extraExtensionsProp,
+    placeholder,
+    placeholderCompartment,
+    runKeymap,
+    updateListener,
+    value,
+    wrap,
+    wrapCompartment,
+  ])
+
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) return
+    const current = view.state.doc.toString()
+    if (value !== current) {
+      const { main } = view.state.selection
+      const newLength = value.length
+      const anchor = Math.min(main.anchor, newLength)
+      const head = Math.min(main.head, newLength)
+      view.dispatch({
+        changes: { from: 0, to: current.length, insert: value },
+        selection: { anchor, head },
+      })
+    }
+  }, [value])
+
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) return
+    view.dispatch({
+      effects: wrapCompartment.reconfigure(wrap ? EditorView.lineWrapping : []),
+    })
+  }, [wrap, wrapCompartment])
+
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) return
+    const extension = placeholder ? cmPlaceholder(placeholder) : []
+    view.dispatch({
+      effects: placeholderCompartment.reconfigure(extension),
+    })
+  }, [placeholder, placeholderCompartment])
+
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) return
+    view.dispatch({
+      effects: extraExtensionsCompartment.reconfigure(extraExtensionsProp || []),
+    })
+  }, [extraExtensionsCompartment, extraExtensionsProp])
 
   const getSelection = useCallback(() => {
-    const textarea = textareaRef.current
-    if (!textarea) return ''
-    const selectionStart = textarea.selectionStart ?? 0
-    const selectionEnd = textarea.selectionEnd ?? selectionStart
-    if (selectionStart === selectionEnd) return ''
-    return textarea.value.slice(selectionStart, selectionEnd)
+    const view = viewRef.current
+    if (!view) return ''
+    const { main } = view.state.selection
+    if (main.empty) return ''
+    return view.state.sliceDoc(main.from, main.to)
   }, [])
 
   const getValue = useCallback(() => {
-    return textareaRef.current ? textareaRef.current.value : ''
+    return viewRef.current ? viewRef.current.state.doc.toString() : ''
   }, [])
 
   const focus = useCallback(() => {
-    textareaRef.current?.focus()
+    viewRef.current?.focus()
   }, [])
 
   const getCursor = useCallback(() => {
-    const textarea = textareaRef.current
-    if (!textarea) return { head: 0, anchor: 0 }
-    const selectionStart = textarea.selectionStart ?? 0
-    const selectionEnd = textarea.selectionEnd ?? selectionStart
-    return { head: selectionEnd, anchor: selectionStart }
+    const view = viewRef.current
+    if (!view) return { head: 0, anchor: 0 }
+    const { main } = view.state.selection
+    return { head: main.head, anchor: main.anchor }
   }, [])
 
-  useImperativeHandle(ref, () => ({
-    getSelection,
-    getValue,
-    focus,
-    getCursor,
-  }), [focus, getCursor, getSelection, getValue])
-
-  const insertTextAtSelection = useCallback((text) => {
-    const textarea = textareaRef.current
-    if (!textarea) return
-    const selectionStart = textarea.selectionStart ?? 0
-    const selectionEnd = textarea.selectionEnd ?? selectionStart
-    const currentValue = textarea.value ?? ''
-    const nextValue = `${currentValue.slice(0, selectionStart)}${text}${currentValue.slice(selectionEnd)}`
-    if (onChange) onChange(nextValue)
-    window.requestAnimationFrame(() => {
-      if (!textareaRef.current) return
-      const nextPos = selectionStart + text.length
-      textareaRef.current.selectionStart = nextPos
-      textareaRef.current.selectionEnd = nextPos
-      emitSelectionState()
-    })
-  }, [emitSelectionState, onChange])
-
-  const handleKeyDown = useCallback((event) => {
-    if (event.key === 'Tab') {
-      event.preventDefault()
-      insertTextAtSelection('  ')
-      return
-    }
-    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
-      event.preventDefault()
-      if (event.shiftKey) {
-        if (onRunSelection) onRunSelection()
-        else if (onRun) onRun()
-        return
-      }
-      if (onRun) onRun()
-    }
-  }, [insertTextAtSelection, onRun, onRunSelection])
-
-  const handleChange = useCallback((event) => {
-    if (onChange) onChange(event.target.value)
-    window.requestAnimationFrame(() => {
-      emitSelectionState()
-    })
-  }, [emitSelectionState, onChange])
-
-  const handleFocus = useCallback(() => {
-    if (onFocus) onFocus()
-  }, [onFocus])
-
-  const handleSelectionEvent = useCallback(() => {
-    emitSelectionState()
-  }, [emitSelectionState])
-
-  useEffect(() => {
-    if (onSelectionChange) onSelectionChange('')
-  }, [onSelectionChange])
-
-  useEffect(() => {
-    emitSelectionState()
-  }, [emitSelectionState, value])
-
-  const whitespaceClass = wrap ? 'whitespace-pre-wrap break-words' : 'whitespace-pre'
+  useImperativeHandle(
+    ref,
+    () => ({
+      getSelection,
+      getValue,
+      focus,
+      getCursor,
+    }),
+    [focus, getCursor, getSelection, getValue],
+  )
 
   return (
     <div className='rounded-lg border-2 border-black bg-white overflow-hidden'>
-      <textarea
-        ref={textareaRef}
-        value={value}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        onKeyUp={handleSelectionEvent}
-        onSelect={handleSelectionEvent}
-        onMouseUp={handleSelectionEvent}
-        onFocus={handleFocus}
-        placeholder={placeholder}
-        spellCheck={false}
-        autoComplete='off'
-        autoCorrect='off'
-        autoCapitalize='none'
-        aria-label='SQL editor'
-        className={`h-72 w-full resize-none bg-transparent p-3 font-mono text-sm leading-6 text-gray-900 outline-none ${whitespaceClass} overflow-auto`}
-        wrap={wrap ? 'soft' : 'off'}
-      />
+      <div className='h-72' ref={containerRef} />
     </div>
   )
 })


### PR DESCRIPTION
## Summary
- replace the textarea-based SQL editor with a CodeMirror 6 implementation in the Query Explorer tool
- keep existing shortcuts, selection reporting, and support for future extensions while matching the monochrome styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5d2743f84832ea789d35ceb578566