### PR TITLE
Add audio sharing option to Microphone Transcriber

### DIFF
--- a/src/components/MicrophoneTranscriber.jsx
+++ b/src/components/MicrophoneTranscriber.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { IconMicrophone, IconPlayerStop, IconUpload, IconCopy, IconDownload } from '@tabler/icons-react'
+import { IconMicrophone, IconPlayerStop, IconUpload, IconCopy, IconDownload, IconShare } from '@tabler/icons-react'
 import { marked } from 'marked'
 import { getApiKey } from '../lib/config.js'
 import Disclosure from './Disclosure.jsx'
@@ -339,12 +339,7 @@ export default function MicrophoneTranscriber() {
     URL.revokeObjectURL(url)
   }
 
-  const handleDownloadAudio = () => {
-    if (!audioBlob) return
-    const url = URL.createObjectURL(audioBlob)
-    const a = document.createElement('a')
-    a.href = url
-    // pick extension from mime
+  const getRecordingFileName = () => {
     let ext = 'webm'
     const mt = (mimeType || '').split(';')[0]
     if (mt === 'audio/ogg') ext = 'ogg'
@@ -352,12 +347,46 @@ export default function MicrophoneTranscriber() {
     else if (mt === 'audio/webm') ext = 'webm'
     const ts = new Date()
     const pad = (n) => String(n).padStart(2, '0')
-    const name = `recording-${ts.getFullYear()}${pad(ts.getMonth()+1)}${pad(ts.getDate())}-${pad(ts.getHours())}${pad(ts.getMinutes())}${pad(ts.getSeconds())}.${ext}`
+    return `recording-${ts.getFullYear()}${pad(ts.getMonth()+1)}${pad(ts.getDate())}-${pad(ts.getHours())}${pad(ts.getMinutes())}${pad(ts.getSeconds())}.${ext}`
+  }
+
+  const handleDownloadAudio = () => {
+    if (!audioBlob) return
+    const url = URL.createObjectURL(audioBlob)
+    const a = document.createElement('a')
+    a.href = url
+    const name = getRecordingFileName()
     a.download = name
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
     URL.revokeObjectURL(url)
+  }
+
+  const handleShareAudio = async () => {
+    if (!audioBlob) return
+    if (!navigator.share) {
+      setStatus('Sharing is not supported on this browser.')
+      return
+    }
+    try {
+      const name = getRecordingFileName()
+      const file = new File([audioBlob], name, { type: mimeType || 'audio/webm' })
+      const shareData = {
+        files: [file],
+        title: 'Microphone Transcriber recording',
+        text: 'Recorded with the Microphone Transcriber tool.',
+      }
+      if (navigator.canShare && !navigator.canShare(shareData)) {
+        setStatus('Sharing is not available for audio files on this device.')
+        return
+      }
+      await navigator.share(shareData)
+      setStatus('Share sheet opened.')
+    } catch (error) {
+      if (error?.name === 'AbortError') return
+      setStatus('Failed to share audio.')
+    }
   }
 
   const previewHtml = useMemo(() => (markdown ? marked.parse(markdown) : ''), [markdown])
@@ -391,6 +420,15 @@ export default function MicrophoneTranscriber() {
                       title="Download audio"
                     >
                       <IconDownload size={18} stroke={2} />
+                    </button>
+                    <button
+                      onClick={handleShareAudio}
+                      aria-label="Share audio"
+                      className="shrink-0 bg-white border-2 border-black text-black rounded-lg p-2 hover:bg-gray-100 focus:outline-none"
+                      disabled={!audioBlob}
+                      title="Share audio"
+                    >
+                      <IconShare size={18} stroke={2} />
                     </button>
                   </div>
                   <div className="mt-1 text-sm text-gray-700">


### PR DESCRIPTION
## Summary
- add a helper to reuse the generated recording filename
- introduce an audio sharing handler using the Web Share API
- render a share button next to the audio download button in the Microphone Transcriber

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e8f2bf414c832ea26264c6c417f749